### PR TITLE
사이드 바 스크롤 수정, 글꼴과 글자 호버 위치 등 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
 				<div class="even-sidebar-inner">
 					<div class="even-sidebar-item">
 						<div class="items icon-1"></div>
-						<div class="items sidebar-text">홈</div>
+						<div class="items sidebar-text weight300">홈</div>
 					</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-2"></div>
-						<div class="items sidebar-text">Shorts</div>
+						<div class="items sidebar-text weight300">Shorts</div>
 					</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-3"></div>
@@ -33,7 +33,7 @@
 					</div>
 				</div>
 				<div class="even-sidebar-inner menu">
-					<div class="even-sidebar-menu">내 페이지 ></div>
+					<div class="even-sidebar-menu menu-hover weight200">내 페이지 ></div>
 					<div class="even-sidebar-item">
 						<div class="items icon-4"></div>
 						<div class="items sidebar-text">시청 기록</div>
@@ -100,19 +100,19 @@
 					<div class="even-sidebar-menu">YouTube 더보기</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-18"></div>
-						<div class="items sidebar-text">YouTube Premium</div>
+						<div class="items sidebar-text weight300">YouTube Premium</div>
 					</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-19"></div>
-						<div class="items sidebar-text">YouTube 스튜디오</div>
+						<div class="items sidebar-text weight300">YouTube 스튜디오</div>
 					</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-20"></div>
-						<div class="items sidebar-text">YouTube Music</div>
+						<div class="items sidebar-text weight300">YouTube Music</div>
 					</div>
 					<div class="even-sidebar-item">
 						<div class="items icon-21"></div>
-						<div class="items sidebar-text">YouTube Kids</div>
+						<div class="items sidebar-text weight300">YouTube Kids</div>
 					</div>
 				</div>
 				<!-- 설정 -->

--- a/styles/general.css
+++ b/styles/general.css
@@ -1,10 +1,12 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 
 body {
+    height: 100vh;
     margin: 0;
     padding: 0;
     background-color: #0f0f0f;
-    color: #fff;
-    font-family: "Roboto", "Arial", sans-serif;
+    color: #f1f1f1;
+    font-family: "Roboto", "Arial", "Noto Sans KR", sans-serif;
     /* display: block; (기본값) */
 }

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -1,32 +1,34 @@
 /* 사이드바 기본 (확장) */
 .even-sidebar{
-	width:228px;
-}
-.even-sidebar-container {
-	width: 228px;
-	display: flex;
-	align-items: center;
-	padding-right: 12px; 
-	overflow-x: hidden;
-	overflow-y: scroll;
+	width: 240px;
+	height: 100vh;
+	position: fixed;
+	top: 0;
+	left: 0;
+	overflow: hidden;
+	padding-right: 16px;
 }
 
 /* 사이드바 스크롤 */
-::-webkit-scrollbar {
-	background: #0f0f0f;
-	width: 8px;
+.even-sidebar:hover {
+	overflow-y: scroll; /* 사이드 바 호버 시 스크롤 보이기 */
 }
 
-::-webkit-scrollbar-thumb {
-	background: #0f0f0f;
+.even-sidebar::-webkit-scrollbar {
+    width: 5px;
+    background: transparent; /* 스크롤 트랙 색상 투명 */
+}
+
+.even-sidebar::-webkit-scrollbar-thumb {
 	border-radius: 10px;
-}
-::-webkit-scrollbar-thumb:hover {
-	background: rgba(255, 255, 255, 0.5);
+	background: rgba(255, 255, 255, 0.4); /* 스크롤 색상과 투명도 */
 }
 
-::-webkit-scrollbar-thumb:focus {
-	background: rgba(255, 255, 255, 0.5);
+/* container */
+.even-sidebar-container {
+	width: 240px;
+	display: flex;
+	align-items: center;
 }
 
 /* section */
@@ -37,36 +39,42 @@
 }
 
 .even-sidebar-inner {
-	padding: 0 20px;
+	padding: 0 10px;
+	padding-bottom: 10px;
 }
 
 .even-sidebar-inner.menu {
-	border-top: 1px solid rgba(255, 255, 255, 0.1);
+	border-top: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .even-sidebar-inner.menu-bottom {
-	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	padding: 10px 20px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+	padding: 10px 10px;
 }
 
+/* 사이드바 메뉴 */
 .even-sidebar-menu {
 	width: 200px;
 	height: 40px;
 	margin: 6px 0;
 	font-size: 16px;
 	align-content: center;
+	padding-left: 10px;
+	cursor: default;
 }
 
-.even-sidebar-menu:hover {
+.menu-hover:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 	border-radius: 10px;
+	cursor: pointer;
 }
 
-.even-sidebar-menu:active {
+.menu-hover:active {
 	background-color: rgba(255, 255, 255, 0.2);
 	border-radius: 10px;
 }
 
+/* 사이드바 아이템 */
 .even-sidebar-item {
 	width: 200px;
 	display: flex;
@@ -74,11 +82,8 @@
 	margin: 6px 0;
 	font-weight: 300;
 	font-size: 14px;
-}
-
-.even-sidebar-menu {
-	margin: 12px 0;
-	font-size: 20px;
+	padding-left: 10px;
+	align-items: center;
 }
 
 .even-sidebar-item:hover {
@@ -101,6 +106,17 @@
 .sidebar-text {
 	width: 200px;
 	padding: 5px 0;
+	line-height: 25px;
+	font-weight: 100;
+	color: #f1f1f1;
+}
+
+.weight200 {
+	font-weight: 200;
+}
+
+.weight300 {
+	font-weight: 300;
 }
 
 /* 위에서부터 순서대로 아이콘 배치 */
@@ -245,7 +261,7 @@
 	background-color: transparent;
 	color: rgb(176, 176, 176);
 	font-size: 12.5px;
-	font-weight: 600;
+	font-weight: 500;
 	letter-spacing: 0.3px;
 }
 
@@ -276,7 +292,7 @@
 	width: 195px;
 	color: #717171;
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 400;
 	line-height: 17px;
 	letter-spacing: 0.1px;
 	margin-bottom: 15px;
@@ -294,7 +310,7 @@
 	display: inline;
 	font-size: inherit;
 	font-family: inherit;
-	padding: 1px 2px;
+	padding: 1px 1px;
 	border: none;
 	background-color: transparent;
 	color: rgb(11, 180, 253);
@@ -399,7 +415,7 @@
 
 @media (min-width: 1313px) {
 	.even-sidebar {
-		display: flex;
+		display: block;
 	}
 	.even-mini-sidebar {
 		display: none;


### PR DESCRIPTION
# PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
sidebar/sidebar_SangHwi -> feature/sidebar

# 변경 사항
1. 스크롤 바가 사이드 바 옆에 위치하고 사이드 바 전체 너비에 호버 시 등장하도록 수정했습니다 !
2. 메뉴들 마우스 호버 시, 클릭 시 발생하는 박스의 위치를 가운데로 조정했습니다.
3. 글자 굵기가 영문과 한글이 서로 들쭉날쭉한 부분 수정했습니다. (Roboto 굵기 전체 불러오기, Noto Sans KR 웹폰트 채용)
4. 그 외 아주 작고 소듕한 것들을 유튜브 원본과 비교 수정했습니다. (글자색, 섹션 구분 선 색, 위아래 간격, pointer 적용)

과정에서 나현님이 고생해서 추가해주신 부분을 조금 수정하게 되었습니다 ㅠ
나중에 확인 한 번 부탁드리고 문제 있는 부분이 있다면 꼭 말씀 주세요 🙏🙏
 
.even-sidebar-footer-info-btn { font-weight: 600 -> 500; }
.even-sidebar-footer-copyright {font-weight: 500 -> 400;}
.even-sidebar-footer-copyright-btn {padding: 1px 2px -> 1px 1px;}
(미디어쿼리 1313px 이상일 때) .even-sidebar {display: flex -> block;}

그리고 제가 착각한 부분이 있는데, 
사이드바 자체 헤더가 동영상 시청하는 곳에서만 등장하고 메인 페이지에서는 등장하지 않는 것 같습니다
그래서 저희는 따로 헤더를 추가하지 않아도 될 것 같아요.. 혼선 드려서 죄송합니다 🥲

## 테스트 결과
![스크린샷 2024-12-03 오전 10 24 04](https://github.com/user-attachments/assets/885be56c-4d3c-4995-bfba-41c250ee9b4c)

![스크린샷 2024-12-03 오전 10 24 22](https://github.com/user-attachments/assets/26deba8e-06a5-40df-8654-bdfd7a4a6e8f)

