### PR TITLE
헤더 right section 쏠림 수정

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -11,13 +11,14 @@
 
 .header-container {
 	height: 65px;
+	width: 100%;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-
 	background-color: black;
 	border-bottom: 1px solid black;
 	padding: 0 16px;
+	box-sizing: border-box;
 }
 
 .left-section {
@@ -140,7 +141,6 @@
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
-	justify-content: space-between;
 	gap: 10px;
 }
 
@@ -214,13 +214,14 @@ button:hover #tooltip {
 	cursor: pointer;
 	transition: background-color 0.25s;
 }
+
 .navbar-item:hover {
 	background-color: #737373;
 }
 
 .navbar-item.selected {
-    background-color: white;
-    color: black;
+	background-color: white;
+	color: black;
 	border-color: black;
 }
 


### PR DESCRIPTION
# PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 버그 수정

# 반영 브랜치
ex) feature/header-search-ui -> develop

# 변경 사항
헤더 오른쪽 섹션이 화면 너비가 작아질 경우 왼쪽으로 쏠리는 현상을 수정했습니다.


## 테스트 결과
|수정전|수정후|
|--|--|
|<img width="671" alt="스크린샷 2024-12-03 오후 4 45 12" src="https://github.com/user-attachments/assets/65cd6f51-6f14-4da0-9561-6557396eea87">|<img width="715" alt="스크린샷 2024-12-03 오후 4 44 59" src="https://github.com/user-attachments/assets/df46e87a-0f0c-4d1a-8b90-4592c2838afd">|
